### PR TITLE
Changes to help readability

### DIFF
--- a/GoogleChat/GChat-darkSea.user.css
+++ b/GoogleChat/GChat-darkSea.user.css
@@ -431,9 +431,15 @@ body,
 }
 /* reply bar text */
 .PhFuQe.yXgmRe .dJ9vNe .BScnzc {
-  color: var(--base04)
+  color: var(--base04);
 }
-
+@media (max-width: 375px) {
+  .tRuV8b .dJ9vNe.DbQnIe .oAzRtb {
+    color: var(--base02);
+  }
+  .tRuV8b .vW3yif.DbQnIe .cXQBz, .tRuV8b .dJ9vNe.DbQnIe .cXQBz {
+    color: var(--base02);
+}
 /* reply bar icons */
 .fKz7Od,
 .aOHsTc {
@@ -559,7 +565,7 @@ div .dHI9xe.qs41qe {
   background-color: var(--base02);
 }
 /* menu main options */
-.R5Q1ue .XaOSkb {
+.R5Q1ue .XaOSkb, .jO7h3c {
   color: var(--base3);
 }
 /* menu subtext */

--- a/GoogleChat/GChat-darkSea.user.css
+++ b/GoogleChat/GChat-darkSea.user.css
@@ -583,9 +583,33 @@ div .dHI9xe.qs41qe {
   background-color: var(--base03);
 }
 /* Fix the background color for selected messages */
-  .nF6pT.FwR7Pc .iKCcE, .VYsRpc:hover {
-    background-color: none !important;
-  }
+.nF6pT.FwR7Pc .iKCcE, .VYsRpc:hover {
+  background-color: none !important;
+}
+/* Fix some of the Room UI elements*/
+  /* Tab menu */
+.UDyRYe, .c0lDWe {
+  background-color: var(--base01);
+  border-bottom: var(--base01);
+  color: var(--base1);
+ }
+/* Selected tab underline */
+.ItO8Dd {
+  background-color: var(--base02);
+}
+  /* Tab text */
+.XXAR0 {
+  color: var(--base2);
+}
+  /* Tab hover color */
+.wmFscd.DWWcKd-OomVLb-LgbsSe.DWWcKd-OomVLb-LgbsSe-ZmdkE {
+  background-color: var(--base03);
+  border-radius: 0 0 0 0;
+}
+  /* Selected Tab underline hover */
+.wmFscd.DWWcKd-OomVLb-LgbsSe-gk6SMd.DWWcKd-OomVLb-LgbsSe-ZmdkE .ItO8Dd{
+  background-color: var(--base2);
+}
 
 /* End of userscript code */
 }

--- a/GoogleChat/GChat-darkSea.user.css
+++ b/GoogleChat/GChat-darkSea.user.css
@@ -434,9 +434,11 @@ body,
   color: var(--base04);
 }
 @media (max-width: 375px) {
+  /* text in textbox */
   .tRuV8b .dJ9vNe.DbQnIe .oAzRtb {
     color: var(--base02);
   }
+  /* plus button for textbox actions */
   .tRuV8b .vW3yif.DbQnIe .cXQBz, .tRuV8b .dJ9vNe.DbQnIe .cXQBz {
     color: var(--base02);
 }
@@ -580,6 +582,10 @@ div .dHI9xe.qs41qe {
 .XbbXmb.zzVqCe .nF6pT, .dsoUjb .jGyvbd .jO0Dzb {
   background-color: var(--base03);
 }
+/* Fix the background color for selected messages */
+  .nF6pT.FwR7Pc .iKCcE, .VYsRpc:hover {
+    background-color: none !important;
+  }
 
 /* End of userscript code */
 }


### PR DESCRIPTION
This should resolve Issue #2 

Added rules to:
- detect when pop-up window is less than 375px. This is the breakpoint that Google uses.
- adjusted text color in textbox so the text can be read.
- tweaked the text color of some of the menu options in the 3 dot menu that were too dark to read.
- Added some tweaks to the Room UI so the tabs at the top are colored based upon scheme.